### PR TITLE
Existing code was giving exception on mac

### DIFF
--- a/lib/bench_press/system_information.rb
+++ b/lib/bench_press/system_information.rb
@@ -74,7 +74,7 @@ module BenchPress
     end
 
     def mac?
-      Facter.kernel =~ /Darwin/
+      facts['kernel'] =~ /Darwin/
     end
   end
 end


### PR DESCRIPTION
Existing code was giving exception on mac
for Factor v2.1.0 

``` ruby
bench_press-0.3.1/lib/bench_press/system_information.rb:77:in `mac?': undefined method `kernel' for Facter:Module (NoMethodError)
```
